### PR TITLE
Added missing text align CSS classes

### DIFF
--- a/css/metro-bootstrap.css
+++ b/css/metro-bootstrap.css
@@ -6627,3 +6627,12 @@ textarea:focus {
   height: 10px;
   border-radius: 100%;
 }
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}


### PR DESCRIPTION
Added missing text align CSS classes those are found in original bootstrap.css file
