### PR TITLE
Fix bower warning: remove globs from 'main'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,6 @@
   "version": "3.2.1",
   "main": [
     "./dist/css/metro-bootstrap.css",
-    "./dist/fonts/font-awesome/*.*",
-    "./dist/fonts/glyphicons/*.*"
   ],
   "dependencies": {
     "bootstrap": "~3.2.0",


### PR DESCRIPTION
The bower.json specifically states you are not to include assets like fonts
and globs are not allowed.

See: https://github.com/bower/spec/blob/master/json.md